### PR TITLE
Adding font to theme exports

### DIFF
--- a/change/@pongo-ui-react-theme-f158f0ce-f902-4d8f-b8d3-407d233ac1e2.json
+++ b/change/@pongo-ui-react-theme-f158f0ce-f902-4d8f-b8d3-407d233ac1e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adding font exports",
+  "packageName": "@pongo-ui/react-theme",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-theme/src/themes/index.ts
+++ b/packages/react-theme/src/themes/index.ts
@@ -1,3 +1,3 @@
 export * from './web/index';
 export * from './theme';
-export * from './font';
+export * from './font/index';

--- a/packages/react-theme/src/themes/index.ts
+++ b/packages/react-theme/src/themes/index.ts
@@ -1,2 +1,3 @@
 export * from './web/index';
 export * from './theme';
+export * from './font';


### PR DESCRIPTION
#### Description of changes

The theme package is missing exports for the font tokens. This results in missing tokens when downloading the package.