### PR TITLE
Fixing NextJS provider menu bug

### DIFF
--- a/change/@pongo-ui-react-menu-d4adc7c0-36a5-486b-8455-b7b486265167.json
+++ b/change/@pongo-ui-react-menu-d4adc7c0-36a5-486b-8455-b7b486265167.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updating inline default to be true and bumping zIndex of menu.",
+  "packageName": "@pongo-ui/react-menu",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-button/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/react-button/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`Button Rendered as anchor renders correctly 1`] = `
 <div>
   <a
-    class="___1psemep f10pi13n ftuwxu6 f122n59 f4d9j23 fmrv4ls f1iqk1t4 frurm3d fvpd7ky f8dqhol fmd4ok8 f1rd5vql f1s6fcnf f2hkw1w fdxsi5y f1i4q40k f1ab1e41 f1jd910e f1nw9czy f21wkpv fvk4ntw f1bkt4b4 f16hf5f2 fyyqeim f1qhqcal f1kbdjx9 fw1d893 f14hlsw1 fpuz8dn fgm4zzz f1o1s7a4 f1w999bl fr2bnm2 fs1pkn2 f1uv12qj fygjnvu f19a3h24 f1k6fduh fzbgb85 f1d3e705 f8qjfyk f5ogflp f1hqa2wf f1f09k3d finvdd3 fzkkow9 fcdblym fg706s2 fjik90z f1pylbsr f2vb6v5 f10bif2e f2q6xjf f1b9eglm fvmcm2m f1yjbvjz f2c7chp f1u9aofn f1gzmned fvwc2ds f1rjtmqt fejrb8o fhrm5jc f1hgp6dj fjt3l15 fqvqbqk f1f9t5xu fcv2ht4 fgfbwa2 f1y3hx6l f1g0x7ka f1gbmcue f1qch9an f1rh9g5y f1arxnym f1rbvai9 f13ju9t4 f1lh17z1 f1dlw1sp"
+    class="___19sqjcz f10pi13n ftuwxu6 f122n59 f4d9j23 fmrv4ls f1iqk1t4 frurm3d fvpd7ky f8dqhol fmd4ok8 f1rd5vql f1s6fcnf f2hkw1w fdxsi5y f1i4q40k f1ab1e41 f1jd910e f1nw9czy f21wkpv fvk4ntw f1bkt4b4 f16hf5f2 fyyqeim f1qhqcal f1kbdjx9 fw1d893 f14hlsw1 fpuz8dn fgm4zzz f1o1s7a4 f1w999bl fr2bnm2 fs1pkn2 f1uv12qj fygjnvu f19a3h24 f1k6fduh fzbgb85 f1d3e705 f8qjfyk f5ogflp f1hqa2wf f1f09k3d finvdd3 fzkkow9 fcdblym fg706s2 fjik90z f115dyy7 f1hmi1p7 f1qx9txk fum5b59 f1qhemxn f1tqsw9j fjqzb2 f1412l3w f4re5gv fudp8vv fbjsao4 f1mpkq40 fb3yuvq fg11f5z f6neqwf f71xtra f12v68sz f1f9t5xu fcv2ht4 fgfbwa2 f1y3hx6l f1g0x7ka f1gbmcue f1qch9an f1rh9g5y f1arxnym f1rbvai9 f13ju9t4 f1lh17z1 f1dlw1sp"
     href="https://www.bing.com"
     role="button"
-    style="--pongoai-button-background-color: var(--inherit); --pongoai-button-hover-color: var(--inheritHover); --pongoai-button-pressed-color: var(--inheritPressed); --pongoai-foreground-hover-color: var(--inheritForegroundHover); --pongoai-foreground-pressed-color: var(--inheritForegroundPressed);"
+    style="--pongo-button-background-color: var(--inherit); --pongo-button-hover-color: var(--inheritHover); --pongo-button-pressed-color: var(--inheritPressed); --pongo-foreground-hover-color: var(--inheritForegroundHover); --pongo-foreground-pressed-color: var(--inheritForegroundPressed);"
     tabindex="0"
     type="button"
   >

--- a/packages/react-button/src/components/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/react-button/src/components/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
@@ -4,10 +4,10 @@ exports[`ToggleButton renders renders as anchor correctly 1`] = `
 <div>
   <a
     aria-pressed="false"
-    class="___k97bz70 f10pi13n ftuwxu6 f122n59 f4d9j23 fmrv4ls f1iqk1t4 frurm3d fvpd7ky f8dqhol fmd4ok8 f1rd5vql f1s6fcnf f2hkw1w fdxsi5y f1i4q40k f1ab1e41 f1jd910e f1nw9czy f21wkpv fvk4ntw f1bkt4b4 f16hf5f2 fyyqeim f1qhqcal f1kbdjx9 fw1d893 f14hlsw1 fpuz8dn fgm4zzz f1o1s7a4 f1w999bl fr2bnm2 fs1pkn2 f1uv12qj fygjnvu f19a3h24 f1k6fduh fzbgb85 f1d3e705 f8qjfyk ftac7j7 f1w0yd9v fdwcyh7 f1h0xgbp fzkkow9 fcdblym fg706s2 fjik90z f1pylbsr f2vb6v5 f10bif2e f2q6xjf f1b9eglm fvmcm2m f1yjbvjz f2c7chp f1u9aofn f1gzmned fvwc2ds f1rjtmqt fejrb8o fhrm5jc f1hgp6dj fjt3l15 fqvqbqk f1f9t5xu fcv2ht4 fgfbwa2 f1y3hx6l f1g0x7ka f1gbmcue f1qch9an f1rh9g5y f1arxnym f1rbvai9 f13ju9t4 f1lh17z1 f1dlw1sp"
+    class="___19sqjcz f10pi13n ftuwxu6 f122n59 f4d9j23 fmrv4ls f1iqk1t4 frurm3d fvpd7ky f8dqhol fmd4ok8 f1rd5vql f1s6fcnf f2hkw1w fdxsi5y f1i4q40k f1ab1e41 f1jd910e f1nw9czy f21wkpv fvk4ntw f1bkt4b4 f16hf5f2 fyyqeim f1qhqcal f1kbdjx9 fw1d893 f14hlsw1 fpuz8dn fgm4zzz f1o1s7a4 f1w999bl fr2bnm2 fs1pkn2 f1uv12qj fygjnvu f19a3h24 f1k6fduh fzbgb85 f1d3e705 f8qjfyk f5ogflp f1hqa2wf f1f09k3d finvdd3 fzkkow9 fcdblym fg706s2 fjik90z f115dyy7 f1hmi1p7 f1qx9txk fum5b59 f1qhemxn f1tqsw9j fjqzb2 f1412l3w f4re5gv fudp8vv fbjsao4 f1mpkq40 fb3yuvq fg11f5z f6neqwf f71xtra f12v68sz f1f9t5xu fcv2ht4 fgfbwa2 f1y3hx6l f1g0x7ka f1gbmcue f1qch9an f1rh9g5y f1arxnym f1rbvai9 f13ju9t4 f1lh17z1 f1dlw1sp"
     href="https://www.bing.com"
     role="button"
-    style="--pongoai-button-background-color: var(--inherit); --pongoai-button-hover-color: var(--inheritHover); --pongoai-button-pressed-color: var(--inheritPressed); --pongoai-foreground-hover-color: var(--inheritForegroundHover); --pongoai-foreground-pressed-color: var(--inheritForegroundPressed);"
+    style="--pongo-button-background-color: var(--inherit); --pongo-button-hover-color: var(--inheritHover); --pongo-button-pressed-color: var(--inheritPressed); --pongo-foreground-hover-color: var(--inheritForegroundHover); --pongo-foreground-pressed-color: var(--inheritForegroundPressed);"
     tabindex="0"
     type="button"
   >
@@ -20,8 +20,8 @@ exports[`ToggleButton renders renders correctly 1`] = `
 <div>
   <button
     aria-pressed="false"
-    class="___k97bz70 f10pi13n ftuwxu6 f122n59 f4d9j23 fmrv4ls f1iqk1t4 frurm3d fvpd7ky f8dqhol fmd4ok8 f1rd5vql f1s6fcnf f2hkw1w fdxsi5y f1i4q40k f1ab1e41 f1jd910e f1nw9czy f21wkpv fvk4ntw f1bkt4b4 f16hf5f2 fyyqeim f1qhqcal f1kbdjx9 fw1d893 f14hlsw1 fpuz8dn fgm4zzz f1o1s7a4 f1w999bl fr2bnm2 fs1pkn2 f1uv12qj fygjnvu f19a3h24 f1k6fduh fzbgb85 f1d3e705 f8qjfyk ftac7j7 f1w0yd9v fdwcyh7 f1h0xgbp fzkkow9 fcdblym fg706s2 fjik90z f1pylbsr f2vb6v5 f10bif2e f2q6xjf f1b9eglm fvmcm2m f1yjbvjz f2c7chp f1u9aofn f1gzmned fvwc2ds f1rjtmqt fejrb8o fhrm5jc f1hgp6dj fjt3l15 fqvqbqk f1f9t5xu fcv2ht4 fgfbwa2 f1y3hx6l f1g0x7ka f1gbmcue f1qch9an f1rh9g5y f1arxnym f1rbvai9 f13ju9t4 f1lh17z1 f1dlw1sp"
-    style="--pongoai-button-background-color: var(--inherit); --pongoai-button-hover-color: var(--inheritHover); --pongoai-button-pressed-color: var(--inheritPressed); --pongoai-foreground-hover-color: var(--inheritForegroundHover); --pongoai-foreground-pressed-color: var(--inheritForegroundPressed);"
+    class="___19sqjcz f10pi13n ftuwxu6 f122n59 f4d9j23 fmrv4ls f1iqk1t4 frurm3d fvpd7ky f8dqhol fmd4ok8 f1rd5vql f1s6fcnf f2hkw1w fdxsi5y f1i4q40k f1ab1e41 f1jd910e f1nw9czy f21wkpv fvk4ntw f1bkt4b4 f16hf5f2 fyyqeim f1qhqcal f1kbdjx9 fw1d893 f14hlsw1 fpuz8dn fgm4zzz f1o1s7a4 f1w999bl fr2bnm2 fs1pkn2 f1uv12qj fygjnvu f19a3h24 f1k6fduh fzbgb85 f1d3e705 f8qjfyk f5ogflp f1hqa2wf f1f09k3d finvdd3 fzkkow9 fcdblym fg706s2 fjik90z f115dyy7 f1hmi1p7 f1qx9txk fum5b59 f1qhemxn f1tqsw9j fjqzb2 f1412l3w f4re5gv fudp8vv fbjsao4 f1mpkq40 fb3yuvq fg11f5z f6neqwf f71xtra f12v68sz f1f9t5xu fcv2ht4 fgfbwa2 f1y3hx6l f1g0x7ka f1gbmcue f1qch9an f1rh9g5y f1arxnym f1rbvai9 f13ju9t4 f1lh17z1 f1dlw1sp"
+    style="--pongo-button-background-color: var(--inherit); --pongo-button-hover-color: var(--inheritHover); --pongo-button-pressed-color: var(--inheritPressed); --pongo-foreground-hover-color: var(--inheritForegroundHover); --pongo-foreground-pressed-color: var(--inheritForegroundPressed);"
     type="button"
   >
     Test Button

--- a/packages/react-input/src/components/Option/__snapshots__/Option.test.tsx.snap
+++ b/packages/react-input/src/components/Option/__snapshots__/Option.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Option renders a basic InputWrapper 1`] = `
   <div>
     <div
       aria-checked="false"
-      class="___18gi861 f10pi13n f22iagw f1d2rq10 f1nbblvp f81rol6 f1ov4xf1 frdkuqy f8qjfyk f8dqhol f1arxnym f122n59 f1xqy1su fc467gg f1q8lukm f1ma2n7n f2hkw1w fc85khu f1pxpxw8 f1149fnl fd1orka fgtqheg fq7mjg8 fq9bj62 fy07e8r f1ha6shg f4ltwxu f1284xzw f14dru39 fvabyfg f12y1wz2 f1k6fduh fc73jsq f8mbk1b f3c9x3h"
+      class="___1ivs8b0 f10pi13n f22iagw f1d2rq10 f1nbblvp f81rol6 f1ov4xf1 frdkuqy f8qjfyk f8dqhol f1arxnym f122n59 f1xqy1su fc467gg f1q8lukm f1ma2n7n f2hkw1w fdxsi5y f1i4q40k fa0joat f1yduw8h f1cwgisr f6dtr1x fvk4ntw f1bkt4b4 f16hf5f2 fyyqeim f1qhqcal f1kbdjx9 fw1d893 f14hlsw1 fpuz8dn f1ky8rbl fjfje89 f1k2de6e f1gkyw7i f1k6fduh f1wnz60r fc73jsq f8mbk1b f3c9x3h"
       name="select"
       role="menuitemradio"
       tabindex="0"

--- a/packages/react-menu/etc/react-menu.api.md
+++ b/packages/react-menu/etc/react-menu.api.md
@@ -15,12 +15,13 @@ import type { MenuListProps } from '@fluentui/react-menu';
 import type { MenuListState } from '@fluentui/react-menu';
 import type { MenuPopoverProps } from '@fluentui/react-menu';
 import type { MenuPopoverState } from '@fluentui/react-menu';
-import { MenuProps as MenuProps_2 } from '@fluentui/react-menu';
+import type { MenuProps as MenuProps_2 } from '@fluentui/react-menu';
 import type { MenuState as MenuState_2 } from '@fluentui/react-menu';
 import { MenuTriggerProps } from '@fluentui/react-menu';
+import * as React_2 from 'react';
 
 // @public
-export const Menu: FC<MenuProps_2>;
+export const Menu: React_2.FC<MenuProps>;
 
 // @public (undocumented)
 export const menuFocusRectColor = "--pongo-menu-item-focus-color";

--- a/packages/react-menu/src/components/Menu/Menu.tsx
+++ b/packages/react-menu/src/components/Menu/Menu.tsx
@@ -1,6 +1,16 @@
-import { Menu as FluentUIMenu } from '@fluentui/react-menu';
+import * as React from 'react';
+import { useMenu_unstable, useMenuContextValues_unstable, renderMenu_unstable } from '@fluentui/react-menu';
+import type { MenuProps } from './Menu.types';
 
 /**
  * Wrapper component that manages state for a popup MenuList and MenuTrigger
  */
-export const Menu = FluentUIMenu;
+export const Menu: React.FC<MenuProps> = props => {
+  const state = useMenu_unstable({ inline: true, ...props });
+
+  const contextValues = useMenuContextValues_unstable(state);
+
+  return renderMenu_unstable(state, contextValues);
+};
+
+Menu.displayName = 'Menu';

--- a/packages/react-menu/src/components/MenuPopover/useMenuPopoverStyles.ts
+++ b/packages/react-menu/src/components/MenuPopover/useMenuPopoverStyles.ts
@@ -9,6 +9,7 @@ const useStyles = makeStyles({
     maxWidth: '300px',
     backgroundColor: tokens.canvasColor,
     filter: tokens.elevate,
+    zIndex: 10000,
   },
 });
 

--- a/packages/react-menu/src/stories/Menu.stories.tsx
+++ b/packages/react-menu/src/stories/Menu.stories.tsx
@@ -10,7 +10,7 @@ export const BasicMenuExample = () => {
   };
 
   return (
-    <Menu open={open} onOpenChange={onOpenChange}>
+    <Menu open={open} onOpenChange={onOpenChange} inline={false}>
       <MenuTrigger>
         <Button>Open Menu</Button>
       </MenuTrigger>


### PR DESCRIPTION
#### Description of changes

Fixing a bug in NextJS which caused the Menu to not have any theme tokens provided. This was addressed by switching the Menu to default to inline and bumping the zIndex of the MenuPopover.
